### PR TITLE
#161399836 build Out the Edit Product Endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,7 +12,7 @@ from app.api.v1.resource.views.views_sales import MakeSale, GetSpecificSale
 # v2 imports
 from app.api.v2.resource.models import db
 from app.api.v2.resource.views.views_users import LoginUsers, RegisterUsers
-from app.api.v2.resource.views.views_products import NewProduct
+from app.api.v2.resource.views.views_products import NewProduct, EditProducts
 
 from instance.config import app_config
 
@@ -69,6 +69,7 @@ def create_app(config_name):
 
     # Products Resource v2
     api_endpoint.add_resource(NewProduct, '/api/v2/products')
+    api_endpoint.add_resource(EditProducts, '/api/v2/products/<int:productId>')
 
     # Initializes flask_jwt_extended
     jwt = JWTManager(app)

--- a/app/api/v2/resource/models/db.py
+++ b/app/api/v2/resource/models/db.py
@@ -104,3 +104,21 @@ def check_if_product_exists(name):
             return {'msg' : 'Product already exists'}, 401
     except (Exception, psycopg2.DatabaseError) as error:
         return {'error' : '{}'.format(error)}, 400
+
+def get_quantity_of_products(product):
+    """
+    Helper function to get the quantity of a product
+    Returns the quantity of the product
+    """
+    try:
+        connection = db_connection()
+        cursor = connection.cursor()
+        cursor.execute("SELECT quantity FROM products WHERE product_name = '{}'".format(product))
+        connection.commit()
+        product = cursor.fetchone()
+        cursor.close()
+        connection.close()
+        if product:
+            return product[0]
+    except (Exception, psycopg2.DatabaseError) as error:
+        return {'error' : '{}'.format(error)}, 400

--- a/app/api/v2/resource/models/model_products.py
+++ b/app/api/v2/resource/models/model_products.py
@@ -7,6 +7,7 @@ from app.api.v2.resource.models import db
 
 class Products():
     def add_product(self, name, quantity, product_cost, reorder):
+        """Method to add a product"""
         name = request.json.get('name', None)
         quantity = request.json.get('quantity', None)
         product_cost = request.json.get('product_cost', None)
@@ -40,6 +41,57 @@ class Products():
             connection.commit()
             response = jsonify({'msg':'Product Successfully Created'})
             response.status_code = 201
+            return response
+        except (Exception, psycopg2.DatabaseError) as error:
+            print(error)
+            response = jsonify({'msg':'Problem inserting record into the database'})
+            response.status_code = 400
+            return response
+    
+    def edit_product(self, name, quantity, product_cost, reorder):
+        """Method to edit a product"""
+        name = request.json.get('name', None)
+        quantity = request.json.get('quantity', None)
+        product_cost = request.json.get('product_cost', None)
+        reorder = request.json.get('reorder', None)
+
+        # Get the ID of the user who created the product
+        current_user = get_jwt_identity()
+        userid = current_user['id']
+
+        # Checks for empty fields
+        if name == '' or quantity == '' or product_cost == '' or reorder == '':
+            return {'msg':'Fields cannot be empty'}, 401
+        
+        # Checks for values less than 1
+        if quantity < 1 or product_cost < 1 or reorder < 1:
+            return {'msg':'Values cannot be less than 1'}, 401
+        
+        # Check if a product exists
+        product_duplicate = db.get_quantity_of_products(name)
+        print(product_duplicate)
+        if not product_duplicate:
+            return {'msg':'product does not exist'}, 401
+        
+        # Get the quantity added
+        get_quantity = db.get_quantity_of_products(name)
+        new_total = get_quantity + quantity
+        
+        try:
+            modify_product = """UPDATE products 
+                                SET product_name = '{}', 
+                                    quantity = '{}', 
+                                    product_cost = '{}', 
+                                    reorder = '{}', 
+                                    user_id='{}' 
+                                WHERE product_name = '{}'""".format(name, new_total, product_cost, reorder, userid, name)
+            print(modify_product)
+            connection = db.db_connection()
+            cursor = connection.cursor()
+            cursor.execute(modify_product)
+            connection.commit()
+            response = jsonify({'msg':'Product Successfully Edited'})
+            response.status_code = 200
             return response
         except (Exception, psycopg2.DatabaseError) as error:
             print(error)

--- a/app/api/v2/resource/models/model_products.py
+++ b/app/api/v2/resource/models/model_products.py
@@ -85,7 +85,6 @@ class Products():
                                     reorder = '{}', 
                                     user_id='{}' 
                                 WHERE product_name = '{}'""".format(name, new_total, product_cost, reorder, userid, name)
-            print(modify_product)
             connection = db.db_connection()
             cursor = connection.cursor()
             cursor.execute(modify_product)

--- a/app/api/v2/resource/views/views_products.py
+++ b/app/api/v2/resource/views/views_products.py
@@ -36,6 +36,9 @@ class EditProducts(Resource):
     def put(self):
         """Route to handle editing a product"""
         args = parser.parse_args()
+        current_user = get_jwt_identity()
+        if current_user['admin'] == False:
+            return {'msg':'Sorry, this route is only accessible to admins'}, 403
         return Products().add_product(
             args['name'],
             args['quantity'],

--- a/app/api/v2/resource/views/views_products.py
+++ b/app/api/v2/resource/views/views_products.py
@@ -27,3 +27,17 @@ class NewProduct(Resource):
             args['quantity'],
             args['product_cost'],
             args['reorder'])
+
+class EditProducts(Resource):
+    """
+    Class to handle editing products
+    PUT /api/v2/products/<int:productId> -> Creates a new products
+    """
+    def put(self):
+        """Route to handle editing a product"""
+        args = parser.parse_args()
+        return Products().add_product(
+            args['name'],
+            args['quantity'],
+            args['product_cost'],
+            args['reorder'])

--- a/app/api/v2/resource/views/views_products.py
+++ b/app/api/v2/resource/views/views_products.py
@@ -33,13 +33,14 @@ class EditProducts(Resource):
     Class to handle editing products
     PUT /api/v2/products/<int:productId> -> Creates a new products
     """
-    def put(self):
+    @jwt_required
+    def put(self, productId):
         """Route to handle editing a product"""
         args = parser.parse_args()
         current_user = get_jwt_identity()
         if current_user['admin'] == False:
             return {'msg':'Sorry, this route is only accessible to admins'}, 403
-        return Products().add_product(
+        return Products().edit_product(
             args['name'],
             args['quantity'],
             args['product_cost'],

--- a/app/tests/v2/test_views_products_v2.py
+++ b/app/tests/v2/test_views_products_v2.py
@@ -21,6 +21,12 @@ class UserTestCase(unittest.TestCase):
             "product_cost":30,
             "reorder":20
         }
+        self.product_edit = {
+            "name":"eggs",
+            "quantity":50,
+            "product_cost":40,
+            "reorder":20
+        }
         self.product2 = {
             "name":"eggs",
             "quantity":30,
@@ -100,5 +106,53 @@ class UserTestCase(unittest.TestCase):
         access_token = json_data.get('access_token')
         self.assertEqual(response.status_code, 200)
         response = self.client().post('/api/v2/products', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product4), content_type='application/json')
+        self.assertEqual(response.status_code, 401)
+        self.assertIn('Values cannot be less than 1', str(response.data))
+
+    def test_edit_product(self):
+        """Test to successfuly edit a product in the database"""
+        response = self.client().post('/api/v2/auth/login', data=json.dumps(self.admin), content_type='application/json')
+        json_data = json.loads(response.data)
+        access_token = json_data.get('access_token')
+        self.assertEqual(response.status_code, 200)
+        response = self.client().post('/api/v2/products', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product1), content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+        response = self.client().post('/api/v2/product/<int:productId>', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product_edit), content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Product successfully edited', str(response.data))
+    
+    def test_edit_missing_values(self):
+        """Test to handle missing parameters"""
+        response = self.client().post('/api/v2/auth/login', data=json.dumps(self.admin), content_type='application/json')
+        json_data = json.loads(response.data)
+        access_token = json_data.get('access_token')
+        self.assertEqual(response.status_code, 200)
+        response = self.client().post('/api/v2/products', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product1), content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+        response = self.client().post('/api/v2/products/<int:productId>', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product2), content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('You must supply the cost of the product', str(response.data))
+    
+    def test_edit_empty_values(self):
+        """Test to handle empty parameters"""
+        response = self.client().post('/api/v2/auth/login', data=json.dumps(self.admin), content_type='application/json')
+        json_data = json.loads(response.data)
+        access_token = json_data.get('access_token')
+        self.assertEqual(response.status_code, 200)
+        response = self.client().post('/api/v2/products', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product1), content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+        response = self.client().post('/api/v2/products/<int:productId>', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product3), content_type='application/json')
+        self.assertEqual(response.status_code, 401)
+        self.assertIn('Fields cannot be empty', str(response.data))
+    
+    def test_edit_megative_values(self):
+        """Test to handle empty parameters"""
+        response = self.client().post('/api/v2/auth/login', data=json.dumps(self.admin), content_type='application/json')
+        json_data = json.loads(response.data)
+        access_token = json_data.get('access_token')
+        self.assertEqual(response.status_code, 200)
+        response = self.client().post('/api/v2/products', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product1), content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+        response = self.client().post('/api/v2/products/<int:productId>', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product4), content_type='application/json')
         self.assertEqual(response.status_code, 401)
         self.assertIn('Values cannot be less than 1', str(response.data))

--- a/app/tests/v2/test_views_products_v2.py
+++ b/app/tests/v2/test_views_products_v2.py
@@ -117,9 +117,11 @@ class UserTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         response = self.client().post('/api/v2/products', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product1), content_type='application/json')
         self.assertEqual(response.status_code, 201)
-        response = self.client().post('/api/v2/product/<int:productId>', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product_edit), content_type='application/json')
+        print(response.data)
+        response = self.client().put('/api/v2/products/1', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product_edit), content_type='application/json')
+        print(response.data)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Product successfully edited', str(response.data))
+        self.assertIn('Product Successfully Edited', str(response.data))
     
     def test_edit_missing_values(self):
         """Test to handle missing parameters"""
@@ -129,7 +131,8 @@ class UserTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         response = self.client().post('/api/v2/products', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product1), content_type='application/json')
         self.assertEqual(response.status_code, 201)
-        response = self.client().post('/api/v2/products/<int:productId>', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product2), content_type='application/json')
+        response = self.client().put('/api/v2/products/1', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product2), content_type='application/json')
+        print(response.data)
         self.assertEqual(response.status_code, 400)
         self.assertIn('You must supply the cost of the product', str(response.data))
     
@@ -141,7 +144,8 @@ class UserTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         response = self.client().post('/api/v2/products', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product1), content_type='application/json')
         self.assertEqual(response.status_code, 201)
-        response = self.client().post('/api/v2/products/<int:productId>', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product3), content_type='application/json')
+        response = self.client().put('/api/v2/products/1', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product3), content_type='application/json')
+        print(response.data)
         self.assertEqual(response.status_code, 401)
         self.assertIn('Fields cannot be empty', str(response.data))
     
@@ -153,6 +157,7 @@ class UserTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         response = self.client().post('/api/v2/products', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product1), content_type='application/json')
         self.assertEqual(response.status_code, 201)
-        response = self.client().post('/api/v2/products/<int:productId>', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product4), content_type='application/json')
+        response = self.client().put('/api/v2/products/1', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product4), content_type='application/json')
+        print(response.data)
         self.assertEqual(response.status_code, 401)
         self.assertIn('Values cannot be less than 1', str(response.data))


### PR DESCRIPTION
#### What does this PR do?
Enable administrators edit a product
#### Description of Task to be completed?

Have administrators log into the app
`POST /api/v2/auth/login`

Have administrators edit an existing product
`PUT /api/v2/products/<int:productId>`

#### How should this be manually tested?

- Clone the repo locally
- Create virtual environmnet and run `pytest`
- In postman use the following body to log in

```
{
    "name":"admin",
    "password":"passadmin"
}
```

- In postman use the following JSON body to add a new product

```
{
	"name":"milk",
	"quantity":50,
	"product_cost":20,
	"reorder":40
}
```

#### Any background context you want to provide?

None
#### What are the relevant pivotal tracker stories?

[#161399836](https://www.pivotaltracker.com/story/show/161399836)