### PR TITLE
#161399903 Build out the Delete Product Endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,7 +12,7 @@ from app.api.v1.resource.views.views_sales import MakeSale, GetSpecificSale
 # v2 imports
 from app.api.v2.resource.models import db
 from app.api.v2.resource.views.views_users import LoginUsers, RegisterUsers
-from app.api.v2.resource.views.views_products import NewProduct
+from app.api.v2.resource.views.views_products import NewProduct, EditProducts
 
 from instance.config import app_config
 
@@ -69,6 +69,7 @@ def create_app(config_name):
 
     # Products Resource v2
     api_endpoint.add_resource(NewProduct, '/api/v2/products')
+    api_endpoint.add_resource(EditProducts, '/api/v2/products/<int:productId>')
 
     # Initializes flask_jwt_extended
     jwt = JWTManager(app)

--- a/app/api/v2/resource/models/db.py
+++ b/app/api/v2/resource/models/db.py
@@ -104,3 +104,22 @@ def check_if_product_exists(name):
             return {'msg' : 'Product already exists'}, 401
     except (Exception, psycopg2.DatabaseError) as error:
         return {'error' : '{}'.format(error)}, 400
+
+def get_db_id(table_name = None, column = None, data = None):
+    """
+    Helper function to fetch an id from the db
+    Returns the id of a product if it exists
+    """
+    try:
+        connection = db_connection()
+        cursor = connection.cursor()
+        cursor.execute("SELECT * FROM {} WHERE {} = {}".format(table_name, column, data))
+        connection.commit()
+        get_id = cursor.fetchone()
+        cursor.close()
+        connection.close()
+        if get_id == None:
+            return False
+        return True
+    except (Exception, psycopg2.DatabaseError) as error:
+        return {'error' : '{}'.format(error)}, 400

--- a/app/api/v2/resource/models/model_products.py
+++ b/app/api/v2/resource/models/model_products.py
@@ -46,3 +46,25 @@ class Products():
             response = jsonify({'msg':'Problem inserting record into the database'})
             response.status_code = 400
             return response
+    
+    def delete_product(self, productId):
+        """Method to delete a product"""
+
+        # Check if the product exists
+        id = db.get_db_id(table_name = 'products', column = 'product_id', data = productId)
+        if id == False:
+            return {'msg':'Product does not exist'}, 404
+        
+        try:
+            product_delete = "delete from products where product_id = {}".format(productId)
+            connection = db.db_connection()
+            cursor = connection.cursor()
+            cursor.execute(product_delete)
+            connection.commit()
+            response = jsonify({'msg':'Product Successfully Deleted'})
+            response.status_code = 200
+            return response
+        except (Exception, psycopg2.DatabaseError) as error:
+            response = jsonify({'msg':'Problem inserting record into the database'})
+            response.status_code = 400
+            return response

--- a/app/api/v2/resource/views/views_products.py
+++ b/app/api/v2/resource/views/views_products.py
@@ -27,3 +27,11 @@ class NewProduct(Resource):
             args['quantity'],
             args['product_cost'],
             args['reorder'])
+    
+class EditProducts(Resource):
+    """
+    Class to handle editing products
+    DELETE /api/v2/products/<int:productId> -> Deletes a product
+    """
+    def delete(self, productId):
+        return Products().delete_product(productId)

--- a/app/api/v2/resource/views/views_products.py
+++ b/app/api/v2/resource/views/views_products.py
@@ -17,7 +17,7 @@ class NewProduct(Resource):
     """
     @jwt_required
     def post(self):
-        """Route to handle creating users"""
+        """Route to handle creating products"""
         args = parser.parse_args()
         current_user = get_jwt_identity()
         if current_user['admin'] == False:
@@ -33,5 +33,10 @@ class EditProducts(Resource):
     Class to handle editing products
     DELETE /api/v2/products/<int:productId> -> Deletes a product
     """
+    @jwt_required
     def delete(self, productId):
+        """Route to delete a product"""
+        current_user = get_jwt_identity()
+        if current_user['admin'] == False:
+            return {'msg':'Sorry, this route is only accessible to admins'}, 403
         return Products().delete_product(productId)

--- a/app/tests/v2/test_views_products_v2.py
+++ b/app/tests/v2/test_views_products_v2.py
@@ -112,8 +112,8 @@ class UserTestCase(unittest.TestCase):
         response = self.client().post('/api/v2/products', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product1), content_type='application/json')
         self.assertEqual(response.status_code, 201)
         response = self.client().delete('/api/v2/products/1', headers = {"Authorization":"Bearer " + access_token}, content_type='application/json')
-        self.assertEqual(response.status_code, 204)
-        self.assertIn('Product successfully deleted', str(response.data))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Product Successfully Deleted', str(response.data))
     
     def test_delete_a_product_that_doesnt_exist(self):
         """Tests to delete a product that does not exist"""
@@ -126,3 +126,15 @@ class UserTestCase(unittest.TestCase):
         response = self.client().delete('/api/v2/products/2', headers = {"Authorization":"Bearer " + access_token}, content_type='application/json')
         self.assertEqual(response.status_code, 404)
         self.assertIn('Product does not exist', str(response.data))
+    
+    def test_if_route_does_not_contain_integers(self):
+        """Tests to check if an integer is not contained in the route"""
+        response = self.client().post('/api/v2/auth/login', data=json.dumps(self.admin), content_type='application/json')
+        json_data = json.loads(response.data)
+        access_token = json_data.get('access_token')
+        self.assertEqual(response.status_code, 200)
+        response = self.client().post('/api/v2/products', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product1), content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+        response = self.client().delete('/api/v2/products/milk', headers = {"Authorization":"Bearer " + access_token}, content_type='application/json')
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('Page not found.', str(response.data))

--- a/app/tests/v2/test_views_products_v2.py
+++ b/app/tests/v2/test_views_products_v2.py
@@ -102,3 +102,27 @@ class UserTestCase(unittest.TestCase):
         response = self.client().post('/api/v2/products', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product4), content_type='application/json')
         self.assertEqual(response.status_code, 401)
         self.assertIn('Values cannot be less than 1', str(response.data))
+    
+    def test_delete_a_product(self):
+        """Tests to delete a product from the db"""
+        response = self.client().post('/api/v2/auth/login', data=json.dumps(self.admin), content_type='application/json')
+        json_data = json.loads(response.data)
+        access_token = json_data.get('access_token')
+        self.assertEqual(response.status_code, 200)
+        response = self.client().post('/api/v2/products', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product1), content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+        response = self.client().delete('/api/v2/products/1', headers = {"Authorization":"Bearer " + access_token}, content_type='application/json')
+        self.assertEqual(response.status_code, 204)
+        self.assertIn('Product successfully deleted', str(response.data))
+    
+    def test_delete_a_product_that_doesnt_exist(self):
+        """Tests to delete a product that does not exist"""
+        response = self.client().post('/api/v2/auth/login', data=json.dumps(self.admin), content_type='application/json')
+        json_data = json.loads(response.data)
+        access_token = json_data.get('access_token')
+        self.assertEqual(response.status_code, 200)
+        response = self.client().post('/api/v2/products', headers = {"Authorization":"Bearer " + access_token}, data=json.dumps(self.product1), content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+        response = self.client().delete('/api/v2/products/2', headers = {"Authorization":"Bearer " + access_token}, content_type='application/json')
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('Product does not exist', str(response.data))


### PR DESCRIPTION
#### What does this PR do?

Enable administrators delete a product
#### Description of Task to be completed?

Have administrators log into the app

`POST /api/v2/auth/login`

Have administrators delete an existing product

`DELETE /api/v2/products/<int:productId>`

#### How should this be manually tested?
- Clone the repo locally
- Create virtual environmnet and run pytest
- In postman use the following body to log in

{
    "name":"admin",
    "password":"passadmin"
}

- In Postman use the route `/api/v2/products/1` to delete a product from the database
#### Any background context you want to provide?

None
#### What are the relevant pivotal tracker stories?

[#161399903](https://www.pivotaltracker.com/story/show/161399903)